### PR TITLE
Bugfix/exception : ErrorMessage 출력이 null로 출력 되는 오류 수정

### DIFF
--- a/src/main/java/com/blueprintto3d/exception/AppException.java
+++ b/src/main/java/com/blueprintto3d/exception/AppException.java
@@ -13,8 +13,9 @@ public class AppException extends RuntimeException{
     private String message;
 
     public AppException(ErrorCode errorCode) {
+        super(errorCode.getMessage()); // 여기를 수정
         this.errorCode = errorCode;
-        this.message = getMessage();
+        this.message = super.getMessage(); // 여기를 수정
     }
 
     @Override

--- a/src/main/java/com/blueprintto3d/exception/ExceptionManager.java
+++ b/src/main/java/com/blueprintto3d/exception/ExceptionManager.java
@@ -13,12 +13,13 @@ public class ExceptionManager {
     @ExceptionHandler(AppException.class)
     public ResponseEntity<?> AppExceptionHandler (AppException e) {
         return ResponseEntity.status(e.getErrorCode().getStatus())
-                .body(Response.error(new ErrorResponse(e.getErrorCode().name(), e.toString())));
+                .body(Response.error(new ErrorResponse(e.getErrorCode().name(), e.getErrorCode().getMessage())));
     }
 
     @ExceptionHandler(SQLException.class)
     public ResponseEntity<?> sqlExceptionHandler(SQLException e) {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(Response.error(new ErrorResponse(ErrorCode.DATABASE_ERROR.name(), toString())));
+                .body(Response.error(new ErrorResponse(ErrorCode.DATABASE_ERROR.name(), e.getMessage())));
     }
 }
+


### PR DESCRIPTION
## 🌟(#21 ) ErrorMessage 출력이 null로 출력 되는 오류 수정


## ✍️내용
- AppException  getMessage() 메소드 호출이 아닌, errorCode.getMessage()를 통해 에러 메시지를 얻어오게 수정
- ExceptionManager에서 e.getErrorCode().getMessage()를 호출하여 ErrorCode에 설정된 메시지를 얻어오게 수정

## 📸스크린샷


## 🎈참고사항
